### PR TITLE
Fix context

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 package-id = fhir.base.template
 
 Base IG template managed by HL7 but usable by anyone (no logos).  The foundation for most HL7-published IGs
+
+see ... for autobuild ...

--- a/README.md
+++ b/README.md
@@ -2,5 +2,3 @@
 package-id = fhir.base.template
 
 Base IG template managed by HL7 but usable by anyone (no logos).  The foundation for most HL7-published IGs
-
-see ... for autobuild ...

--- a/layouts/layout-ext.html
+++ b/layouts/layout-ext.html
@@ -49,10 +49,10 @@
   <p>This extension may be used on the following {{site.data.structuredefinitions['{{[id]}}'].contextType}} element(s):</p>
   <ul>
     {% for context in site.data.structuredefinitions['{{[id]}}'].contexts %}
-    <li>{{context}}</li>
+    <li>{{context.type}}</li>
     {% endfor %}
   </ul>
-  
+
   {% assign intro = site.data.pages[page.path].intro %}
   {% if site.data.pages[page.path].intro != null %}
   <div style="display:inline-block">
@@ -62,7 +62,7 @@
 
   <p><b>Usage info</b></p>
   {%include StructureDefinition-{{[id]}}-sd-xref.xhtml%}
-  
+
   <!-- no uri -->
   <a name="profile"> </a>
   <h3 id="profile">Formal Views of Extension Content</h3>
@@ -223,7 +223,7 @@
   <a name="tx"> </a>
   <h3 id="tx">Terminology Bindings</h3>
   {%include StructureDefinition-{{[id]}}-tx.xhtml%}
-  
+
   <a name="inv"> </a>
   <h3 id="inv">Constraints</h3>
   {%include StructureDefinition-{{[id]}}-inv.xhtml%}


### PR DESCRIPTION
issue: see how is currently rendered as a liquid object here:

https://build.fhir.org/ig/HL7/davinci-crd/StructureDefinition-ext-insurance.html

this removes make it simply the type:
![fix_context](https://user-images.githubusercontent.com/7410922/84341371-c2fbae80-ab57-11ea-87a0-2c9ed26912f3.png)
