### PR TITLE
Fix dup headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 package-id = fhir.base.template
 
 Base IG template managed by HL7 but usable by anyone (no logos).  The foundation for most HL7-published IGs
+
+see ... for autobuild ...

--- a/README.md
+++ b/README.md
@@ -2,5 +2,3 @@
 package-id = fhir.base.template
 
 Base IG template managed by HL7 but usable by anyone (no logos).  The foundation for most HL7-published IGs
-
-see ... for autobuild ...

--- a/layouts/layout-ext.html
+++ b/layouts/layout-ext.html
@@ -52,7 +52,7 @@
     <li>{{context}}</li>
     {% endfor %}
   </ul>
-  
+
   {% assign intro = site.data.pages[page.path].intro %}
   {% if site.data.pages[page.path].intro != null %}
   <div style="display:inline-block">
@@ -62,7 +62,7 @@
 
   <p><b>Usage info</b></p>
   {%include StructureDefinition-{{[id]}}-sd-xref.xhtml%}
-  
+
   <!-- no uri -->
   <a name="profile"> </a>
   <h3 id="profile">Formal Views of Extension Content</h3>
@@ -221,11 +221,11 @@
   <p>Other representations of extension: <a href="{{[type]}}-{{[id]}}.sch">Schematron</a>
   </p>
   <a name="tx"> </a>
-  <h3 id="tx">Terminology Bindings</h3>
+  <!--Terminology Bindings heading in the fragment -->
   {%include StructureDefinition-{{[id]}}-tx.xhtml%}
-  
+
   <a name="inv"> </a>
-  <h3 id="inv">Constraints</h3>
+  <!--Constraints  heading in the fragment -->
   {%include StructureDefinition-{{[id]}}-inv.xhtml%}
 
   {% assign notes = site.data.pages[page.path].notes %}

--- a/layouts/layout-profile.html
+++ b/layouts/layout-profile.html
@@ -219,11 +219,11 @@
   <p>Other representations of profile: <a href="{{[type]}}-{{[id]}}.sch">Schematron</a>
   </p>
   <a name="tx"> </a>
-  <h3 id="tx">Terminology Bindings</h3>
+  <!--Terminology Bindings heading in the fragment -->
   {%include StructureDefinition-{{[id]}}-tx.xhtml%}
 
   <a name="inv"> </a>
-  <h3 id="inv">Constraints</h3>
+  <!--Constraints  heading in the fragment -->
   {%include StructureDefinition-{{[id]}}-inv.xhtml%}
 
   {% assign notes = site.data.pages[page.path].notes %}

--- a/layouts/layout-valueset.html
+++ b/layouts/layout-valueset.html
@@ -9,7 +9,7 @@
     <b>Summary</b>
   </p>
   {%include {{[type]}}-{{[id]}}-summary.xhtml%}
-  
+
   <p>
     <b>References</b>
   </p>
@@ -23,10 +23,10 @@
   {% endif %}
 
   <a name="definition"> </a>
-  <h3 id="definition">Content Logical Definition</h3>
 
+<!-- Content Logical Definition heading in the fragment -->
   {%include {{[type]}}-{{[id]}}-cld.xhtml%}
-  
+
   <p>&#160;</p>
   <a name="expansion"> </a>
   <h3 id="expansion">Expansion</h3>


### PR DESCRIPTION
if you inspect CRD ig you will see duplicate heading in the ValueSet, Profile and Extension pages.  this is because the generated fragments already have heading.  this pr removes the duplicate headings.