### PR TITLE
add type and id variables to notes and intros

### DIFF
--- a/includes/fragment-intro.html
+++ b/includes/fragment-intro.html
@@ -2,11 +2,11 @@
 {% if intro != null %}
 {% if site.data.pages[page.path].intro-type == 'xml' %}
 <div style="display:inline-block">
-{% include {{intro}} %}
+{% include {{intro}} type=include.type id=include.id %}
 </div>
 {% else %}
 {% capture intro-content %}
-{% include {{intro}} %}
+{% include {{intro}} type=include.type id=include.id %}
 {% endcapture %}
 <div style="display:inline-block" markdown="1">
 {{ intro-content | markdownify }}

--- a/includes/fragment-notes.html
+++ b/includes/fragment-notes.html
@@ -3,11 +3,11 @@
 <h3>Notes:</h3>
 {% if site.data.pages[page.path].notes-type == 'xml' %}
 <div style="display:inline-block">
-{% include {{notes}} %}
+{% include {{notes}} type=include.type id=include.id %}
 </div>
 {% else %}
 {% capture note-content %}
-{% include {{notes}} %}
+{% include {{notes}} type=include.type id=include.id %}
 {% endcapture %}
 <div style="display:inline-block" markdown="1">
 {{ note-content | markdownify }}

--- a/layouts/layout-codesystem.html
+++ b/layouts/layout-codesystem.html
@@ -8,7 +8,7 @@
   <h2 id="root">CodeSystem: {{site.data.pages[page.path].title}}</h2>
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   <p>
     <b>Summary</b>
@@ -25,7 +25,7 @@
   {% include {{[type]}}-{{[id]}}-content.xhtml %}
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
   {%include {{[type]}}-{{[id]}}-history.xhtml%}
 

--- a/layouts/layout-conceptmap.html
+++ b/layouts/layout-conceptmap.html
@@ -9,7 +9,7 @@
   <h2 id="root">ConceptMap: {{site.data.pages[page.path].title}}</h2>
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   <p>
   Formats: <a href="{{[type]}}-{{[id]}}.xml.html">XML</a>, <a href="{{[type]}}-{{[id]}}.json.html">JSON</a>, <a href="{{[type]}}-{{[id]}}.ttl.html">Turtle</a>
@@ -18,7 +18,7 @@
   {% include {{[type]}}-{{[name]}}.xhtml %}
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
   {%include {{[type]}}-{{[id]}}-history.xhtml%}
 

--- a/layouts/layout-ext-definitions.html
+++ b/layouts/layout-ext-definitions.html
@@ -10,12 +10,12 @@
   <p>Definitions for the {{[id]}} Profile.</p>
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   {%include StructureDefinition-{{[id]}}-dict.xhtml%}
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
 </div>
 {% assign includetabscripts = 'true' %}

--- a/layouts/layout-ext-mappings.html
+++ b/layouts/layout-ext-mappings.html
@@ -10,12 +10,12 @@
   <p>Mappings for the {{[id]}} Profile.</p>
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   {%include StructureDefinition-{{[id]}}-maps.xhtml%}
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
 </div>
 {% assign includetabscripts = 'true' %}

--- a/layouts/layout-ext.html
+++ b/layouts/layout-ext.html
@@ -23,7 +23,7 @@
   </ul>
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   <p><b>Usage info</b></p>
   {%include StructureDefinition-{{[id]}}-sd-xref.xhtml%}
@@ -194,7 +194,7 @@
   {%include StructureDefinition-{{[id]}}-inv.xhtml%}
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
 </div>
 {% assign includetabscripts = 'true' %}

--- a/layouts/layout-instance-base.html
+++ b/layouts/layout-instance-base.html
@@ -14,12 +14,12 @@
   <h2 id="root">{{example}}{{prefix}}: {{site.data.pages[page.path].title}}</h2>
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   {% include {{[type]}}-{{[name]}}.xhtml %}
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
 </div>
 {% include fragment-pageend.html %}

--- a/layouts/layout-instance-format.html
+++ b/layouts/layout-instance-format.html
@@ -14,12 +14,12 @@
   <p><a href="{{[type]}}-{{[id]}}.{{[fmt]}}">Raw {{[fmt]}}</a></p>
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   {% include {{[type]}}-{{[name]}}.xhtml %}
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
 </div>
 {% include fragment-pageend.html %}

--- a/layouts/layout-profile-definitions.html
+++ b/layouts/layout-profile-definitions.html
@@ -19,12 +19,12 @@
 <p>Definitions for the {{[id]}} Profile.</p>
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   {%include StructureDefinition-{{[id]}}-dict.xhtml%}
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
 </div>
 {% assign includetabscripts = 'true' %}

--- a/layouts/layout-profile-examples.html
+++ b/layouts/layout-profile-examples.html
@@ -16,7 +16,7 @@
   <h2 id="root">{{modelType}}: {{[title]}} - Examples</h2>
 
    <!-- insert intro if present -->
-    {% include fragment-intro.html %}
+    {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
 {% assign basepath = page.path | replace: '-examples.html', '.html' %}
 {% if site.data.pages[basepath].examples.size > 0 %}
@@ -37,7 +37,7 @@
 {% endif %}
 
 <!-- insert notes if present -->
-{% include fragment-notes.html %}
+{% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
 </div>
 {% assign includetabscripts = 'true' %}

--- a/layouts/layout-profile-format.html
+++ b/layouts/layout-profile-format.html
@@ -25,12 +25,12 @@
 <p><a href="{{[type]}}-{{[id]}}.{{format}}">Raw {{format}}</a></p>
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   {%include StructureDefinition-{{[id]}}-{{format}}-html.xhtml%}
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
 </div>
 {% assign includetabscripts = 'true' %}

--- a/layouts/layout-profile-mappings.html
+++ b/layouts/layout-profile-mappings.html
@@ -18,12 +18,12 @@
 <p>Mappings for the {{[id]}} Profile.</p>
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   {%include StructureDefinition-{{[id]}}-maps.xhtml%}
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
 </div>
 {% assign includetabscripts = 'true' %}

--- a/layouts/layout-profile.html
+++ b/layouts/layout-profile.html
@@ -21,7 +21,7 @@
   <pre>{{site.data.structuredefinitions['{{[id]}}'].url}}</pre>
 
 <!-- insert intro if present -->
-{% include fragment-intro.html %}
+{% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   <!-- no uri -->
   <a name="profile"> </a>
@@ -200,7 +200,7 @@
   {%include StructureDefinition-{{[id]}}-inv.xhtml%}
 
 <!-- insert notes if present -->
-{% include fragment-notes.html %}
+{% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
 </div>
 {% assign includetabscripts = 'true' %}

--- a/layouts/layout-valueset.html
+++ b/layouts/layout-valueset.html
@@ -17,7 +17,7 @@
   {%include {{[type]}}-{{[id]}}-xref.xhtml%}
 
   <!-- insert intro if present -->
-  {% include fragment-intro.html %}
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 
   <a name="definition"> </a>
 
@@ -63,7 +63,7 @@
   </table>
 
   <!-- insert notes if present -->
-  {% include fragment-notes.html %}
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
 
   {%include {{[type]}}-{{[id]}}-history.xhtml%}
 


### PR DESCRIPTION
![Untitled 4](https://user-images.githubusercontent.com/7410922/85630357-52a95e80-b628-11ea-86b8-e902fc03fb25.png)

so can use liquid in the notes and intro sections for example:;

~~~
{% assign id = include.id %}

### Mandatory Data Elements and Terminology

The following data-elements are mandatory (i.e data MUST be present).

**Each {{site.data.structuredefinitions.[id].type}} must have:**

1. A subscriber ID

**Additional Profile specific implementation guidance:**

None

### Examples

{% include list-simple-coverages.xhtml %}
~~~