### PR TITLE
add openapi link to format for non example Capstatements

### DIFF
--- a/layouts/layout-instance-base.html
+++ b/layouts/layout-instance-base.html
@@ -13,6 +13,14 @@
 {% assign prefix = site.data.artifacts[page.path].type %}
   <h2 id="root">{{example}}{{prefix}}: {{site.data.pages[page.path].title}}</h2>
 
+{% unless example %}
+  {% if '{{[type]}}' == 'CapabilityStatement' %}
+      <p>
+      <a href="{{[id]}}.openapi.json" no-download="true">Raw OpenAPI-Swagger Definition file</a> | <a href="{{[id]}}.openapi.json" download>Download</a>
+      </p>
+  {% endif %}
+{% endunless %}
+
   <!-- insert intro if present -->
   {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
 


### PR DESCRIPTION
this add open api link for CapStatement after checking if not an example instance.
![Untitled 2](https://user-images.githubusercontent.com/7410922/85758789-7ec6ed00-b6c5-11ea-9051-a0af7a29052e.png)
