### PR TITLE
FIX: link typo

### DIFF
--- a/layouts/layout-profile.html
+++ b/layouts/layout-profile.html
@@ -23,7 +23,7 @@
   <a name="profile"> </a>
   <h3 id="profile">Formal Views of Profile Content</h3>
   <p>
-    <a href="{{site.data.fhir.path}}profiling.html#representation">Description of Profiles, Differentials, Snapshots and how the different presentations work</a>.
+    <a href="{{site.data.fhir.path}}profiling.html#presentation">Description of Profiles, Differentials, Snapshots and how the different presentations work</a>.
   </p>
   <div id="tabs">
     <ul>


### PR DESCRIPTION
the working URL is "http://hl7.org/fhir/R4/profiling.html#presentation" , NOT representation.
PS: Where is the layout-artifacts.html Template? I want change my artifacts page, but I can't find the layout.