### PR TITLE
add text-highlighting

### DIFF
--- a/content/assets/css/project.css
+++ b/content/assets/css/project.css
@@ -607,3 +607,47 @@ li a[href^="http://"]:not([no-external^="true"]):after, a[href^="https://"]:not(
     text-decoration: none;
     padding-left: 3px;
 }
+
+/* ----------New content for ballot styling------*/
+
+.new-content::before {
+  white-space: pre;
+  content: "New Content\A ";
+  color: red;
+  font-weight: bold;}
+.new-content{
+    margin: 5px;
+    padding: 10px;
+    color: #3c763d;
+    background-color: #dff0d8;
+    border-color: #d6e9c6;
+}
+
+.highlight{
+    background-color: yellow;
+    border-color: #0A0008;
+}
+
+.bg-success{
+    color: #3c763d;
+    background-color: #dff0d8;
+    border-color: #bce8f1;
+}
+
+.bg-info{
+    color: #31708f;
+    background-color: #d9edf7;
+    border-color: #d6e9c6;
+}
+
+.bg-warning{
+    color: #8a6d3b;
+    background-color: #fcf8e3;
+    border-color: #faebcc;
+}
+
+.bg-danger{
+    color: #a94442;
+    background-color: #f2dede;
+    border-color: #ebccd1;
+}


### PR DESCRIPTION
see ZULIP:  https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/highlighting.20new.20content.2E
this doesn't provide a way for toggling on or off.  I don't know how to do that off hand whether through css or javascript.


below is example of the following classes:

1. .highlight
1. .bg-danger
1. .bg-success
1. .new-content
1. .bg-info
1. .bg-warning

![image](https://user-images.githubusercontent.com/7410922/87229328-04040000-c35c-11ea-9094-be512ea3250f.png)
