### PR TITLE
fix history template

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,15 +28,11 @@
     },
     {
       "name": "profile-history",
-      "description": "Change History"
-    },
-    {
-      "name": "ext-history",
-      "description": "Change History"
+      "description": "Profile Change History"
     },
     {
       "name": "history",
-      "description": "Change History"
+      "description": "Resource Change History"
     }
   ],
   "_pre-process-documentation": "This array of objects indicates data being converted from existing files using scripts to support dependency checking when performing continuous builds",
@@ -87,7 +83,8 @@
     },
     "ImplementationGuide": {
       "template-base": "",
-      "template-format": ""
+      "template-format": "",
+      "template-history": ""
     },
     "StructureDefinition:extension": {
       "template-base": "template/layouts/layout-ext.html",
@@ -106,7 +103,7 @@
       "profile-xml": "{{[type]}}-{{[id]}}.profile.xml.html",
       "profile-json": "{{[type]}}-{{[id]}}.profile.json.html",
       "profile-ttl": "{{[type]}}-{{[id]}}.profile.ttl.html",
-      "ext-history": "{{[type]}}-{{[id]}}.ext.history.html"
+      "profile-history": "{{[type]}}-{{[id]}}.profile.history.html"
     },
     "StructureDefinition": {
       "template-base": "template/layouts/layout-profile.html",

--- a/includes/fragment-base-navtabs.html
+++ b/includes/fragment-base-navtabs.html
@@ -48,15 +48,15 @@
   {% endif %}
 {% endunless %}
 {% if  site.data.resources[resource_].['history'] %}
-{% if include.active == 'history' %}
-<li class="active">
-  <a href="#">History</a>
-</li>
-{% else %}
-<li>
-  <a href="{{include.type}}-{{include.id}}.history.html">History</a>
-</li>
-{% endif %}
+  {% if include.active == 'history' %}
+    <li class="active">
+      <a href="#">History</a>
+    </li>
+    {% else %}
+    <li>
+      <a href="{{include.type}}-{{include.id}}.history.html">History</a>
+    </li>
+  {% endif %}
 {% endif %}
 
 </ul>

--- a/layouts/layout-history.html
+++ b/layouts/layout-history.html
@@ -2,7 +2,6 @@
 ---
 <!-- get modelType -->
 
-
 {% include fragment-pagebegin.html %}
 
 <div style="counter-reset: section 10" class="col-12">
@@ -10,9 +9,8 @@
   {% include fragment-base-navtabs.html type='{{[type]}}' id='{{[id]}}' active='history' %}
 
   <a name="root"> </a>
-  <h2 id="root">{{type}}: {{[title]}} - Change History</h2>
-  <p>History of changes for {{[id]}} {{type | downcase}}.</p>
-
+  <h2 id="root">{{[type]}}: {{[title]}} - Change History</h2>
+  <p>Changes in the {{[id]}} {{[type]}} resource.</p>
   {%include {{[type]}}-{{[id]}}-history.xhtml%}
 
 </div>


### PR DESCRIPTION
This does not completely fix this issue noted here in  Zuiip:  https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/IG.20History.20page.20links.20cannot.20be.20resolved

but it resolves the IG resource issue and consolidates the extension-history into profiles the issue is as shown in the graphic below is the extension are being treated like regular resource and using the wrong template and hence the wrong tab include file ... so the tabs links are wrong

![Untitled](https://user-images.githubusercontent.com/7410922/87741461-70866100-c799-11ea-9c42-44238164e7a3.png)

don't know where this is encoded but is not following config.json 