### PR TITLE
Fix history links - PLEASE VERIFY

### DIFF
--- a/config.json
+++ b/config.json
@@ -31,7 +31,7 @@
       "description": "Profile Change History"
     },
     {
-      "name": "history",
+      "name": "change-history",
       "description": "Resource Change History"
     }
   ],
@@ -70,7 +70,7 @@
       "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
       "list-types": "CodeSystem|ValueSet",
       "template-history": "template/layouts/layout-history.html",
-      "history": "{{[type]}}-{{[id]}}.history.html"
+      "history": "{{[type]}}-{{[id]}}.change.history.html"
     },
     "example": {
       "java": false,
@@ -79,12 +79,11 @@
       "base": "{{[type]}}-{{[id]}}.html",
       "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
       "template-history": "template/layouts/layout-history.html",
-      "history": "{{[type]}}-{{[id]}}.history.html"
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
     },
     "ImplementationGuide": {
       "template-base": "",
-      "template-format": "",
-      "template-history": ""
+      "template-format": ""
     },
     "StructureDefinition:extension": {
       "template-base": "template/layouts/layout-ext.html",
@@ -114,6 +113,7 @@
       "template-profile-json": "template/layouts/layout-profile-format.html",
       "template-profile-ttl": "template/layouts/layout-profile-format.html",
       "template-profile-history": "template/layouts/layout-profile-history.html",
+      "template-format": "",
       "base": "{{[type]}}-{{[id]}}.html",
       "defns": "{{[type]}}-{{[id]}}-definitions.html",
       "mappings": "{{[type]}}-{{[id]}}-mappings.html",
@@ -129,7 +129,7 @@
       "template-history": "template/layouts/layout-history.html",
       "base": "{{[type]}}-{{[id]}}.html",
       "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
-      "history": "{{[type]}}-{{[id]}}.history.html"
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
     },
     "ConceptMap": {
       "template-base": "template/layouts/layout-conceptmap.html",
@@ -137,15 +137,15 @@
       "template-history": "template/layouts/layout-history.html",
       "base": "{{[type]}}-{{[id]}}.html",
       "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
-      "profile-history": "{{[type]}}-{{[id]}}.history.html"
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
     },
     "ValueSet": {
       "template-base": "template/layouts/layout-valueset.html",
       "template-format": "template/layouts/layout-instance-format.html",
-      "template-history": "template/layouts/layout-history.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
       "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
-      "history": "{{[type]}}-{{[id]}}.history.html"
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
     }
   }
 }

--- a/includes/fragment-base-navtabs.html
+++ b/includes/fragment-base-navtabs.html
@@ -4,6 +4,7 @@
 {% assign resource_ = include.type| append: '/'| append: include.id  %}
 {% assign has_history = site.data.resources[resource_].['history'] %}
 
+
 <ul class="nav nav-tabs">
 {% if include.active == 'content' %}
   <li class="active">
@@ -54,7 +55,7 @@
     </li>
     {% else %}
     <li>
-      <a href="{{include.type}}-{{include.id}}.history.html">History</a>
+      <a href="{{include.type}}-{{include.id}}.change.history.html">History</a>
     </li>
   {% endif %}
 {% endif %}

--- a/includes/fragment-profile-navtabs.html
+++ b/includes/fragment-profile-navtabs.html
@@ -6,6 +6,7 @@
 {% assign sd_type = site.data.structuredefinitions.[include.id].type %}
 {% assign resource_ = include.type| append: '/'| append: include.id  %}
 {% assign has_history = site.data.resources[resource_].['history'] %}
+{% assign basepath = page.path | replace: '-examples.html', '.html' %}
 {% assign basepath = include.type | append: '-' | append: include.id | append: '.html' %}
 {% assign example_count = site.data.pages[basepath].examples.size %}
 

--- a/layouts/layout-changehistory.html
+++ b/layouts/layout-changehistory.html
@@ -1,6 +1,8 @@
 ---
 ---
+<!-- layouts\layout-changehistory.html -->
 <!-- get modelType -->
+
 
 {% include fragment-pagebegin.html %}
 
@@ -9,8 +11,9 @@
   {% include fragment-base-navtabs.html type='{{[type]}}' id='{{[id]}}' active='history' %}
 
   <a name="root"> </a>
-  <h2 id="root">{{[type]}}: {{[title]}} - Change History</h2>
-  <p>Changes in the {{[id]}} {{[type]}} resource.</p>
+  <h2 id="root">{{type}}: {{[title]}} - Change History</h2>
+  <p>History of changes for {{[id]}} {{type | downcase}}.</p>
+
   {%include {{[type]}}-{{[id]}}-history.xhtml%}
 
 </div>


### PR DESCRIPTION
changed all xx.history.html to xx.change.history.html, to avoid conflict with automatically generated history fragment.
Tested this against an IG that has history on a profile and a valueset.

(Still has issue with examples tab being shown in some layouts, hidden in others)