### PR TITLE
add css transitions to smooth page loads

### DIFF
--- a/content/assets/css/project.css
+++ b/content/assets/css/project.css
@@ -646,3 +646,15 @@ li a[href^="http://"]:not([no-external^="true"]):after, a[href^="https://"]:not(
     background-color: #f2dede;
     border-color: #ebccd1;
 }
+
+
+/*--------- smooth transitions ---------- */
+
+body{
+    opacity: 0;
+    transition: opacity 0.7s;
+    -webkit-transition: opacity 0.7s; /* Safari */
+    -ms-transition: opacity 0.7s; /* ie */
+    -o-transition: opacity 0.7s; /* opera */
+    -moz-transition: opacity 0.7s; /* firefox */
+}

--- a/includes/fragment-pagebegin.html
+++ b/includes/fragment-pagebegin.html
@@ -4,16 +4,16 @@
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
     <title>{{site.data.fhir.igId | upcase}}\{{site.data.pages[page.path].title}} - FHIR v{{site.data.fhir.version}}</title>
-  
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="author" content="http://hl7.org/fhir"/>
 
     <link href="{{site.data.info.assets}}fhir.css" rel="stylesheet"/>
-     
+
     <!-- Bootstrap core CSS -->
     <link href="{{site.data.info.assets}}assets/css/bootstrap.css" rel="stylesheet"/>
     <link href="{{site.data.info.assets}}assets/css/bootstrap-fhir.css" rel="stylesheet"/>
-  
+
     <!-- Project extras -->
     <link href="{{site.data.info.assets}}assets/css/project.css" rel="stylesheet"/>
     <link href="{{site.data.info.assets}}assets/css/pygments-manni.css" rel="stylesheet"/>
@@ -27,7 +27,7 @@
     <script src="assets/js/html5shiv.js"></script>
     <script src="assets/js/respond.min.js"></script>
     <![endif]-->
-  
+
     <!-- Favicons -->
     <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{site.data.info.assets}}assets/ico/apple-touch-icon-144-precomposed.png"/>
     <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{site.data.info.assets}}assets/ico/apple-touch-icon-114-precomposed.png"/>
@@ -35,7 +35,7 @@
     <link rel="apple-touch-icon-precomposed" href="{{site.data.info.assets}}assets/ico/apple-touch-icon-57-precomposed.png"/>
     <link rel="shortcut icon" href="{{site.data.info.assets}}assets/ico/favicon.png"/>
   </head>
-  <body>
+  <body onload="document.body.style.opacity='1'">
 {% assign label = {{site.data.pages[page.path].label}} | split: '.0' %}
     <style type="text/css">h2{--heading-prefix:"{{site.data.info.headingOffset}}{{label}}"}
     h3,h4,h5,h6{--heading-prefix:"{{site.data.info.headingOffset}}{{site.data.pages[page.path].label}}"}</style>
@@ -52,12 +52,12 @@
         </div>
       </div> <!-- /container -->
     </div>  <!-- /segment-header -->
-    
+
     <div id="segment-navbar" class="segment">  <!-- segment-navbar -->
       <div id="stripe"> </div>
       <div class="container">  <!-- container -->
         <!-- HEADER CONTENT -->
-    
+
         <nav class="navbar navbar-inverse">
           <!--status-bar-->
           <div class="container">
@@ -77,14 +77,14 @@
     </div>  <!-- /segment-navbar -->
     <!--status-bar-->
     <div id="segment-breadcrumb" class="segment">  <!-- segment-breadcrumb -->
-      <div class="container">  <!-- container -->  
+      <div class="container">  <!-- container -->
         <ul class="breadcrumb">
           {{site.data.pages[page.path].breadcrumb}}
-        </ul>  
+        </ul>
       </div>  <!-- /container -->
     </div>  <!-- /segment-breadcrumb -->
-    
-    <div id="segment-content" class="segment">  <!-- segment-content -->
+
+    <div id="segment-content">  <!-- segment-content -->
       <div class="container">  <!-- container -->
         <div class="row">
           <div class="inner-wrapper">


### PR DESCRIPTION
tested on Chrome, IE, Edge, Firefox and Safari

It is the least effective on Safari since it appears to not wait for page loads..but is still and improvement.

I chose 0.7s as a compromise between the slowest (Chrome) and the fastest transition (Safari)

