### PR TITLE
update ext title to page title

### DIFF
--- a/layouts/layout-ext.html
+++ b/layouts/layout-ext.html
@@ -5,7 +5,7 @@
   <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
   {% include fragment-profile-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
   <a name="root"> </a>
-  <h2 id="root">{{modelType}}: {{site.data.resources['{{[type]}}/{{[id]}}'].title}} ({{site.data.resources['{{[type]}}/{{[id]}}'].name}})</h2>
+  <h2 id="root">Extension: {{site.data.pages[page.path].title}}</h2>
   <p>{{site.data.structuredefinitions['{{[id]}}'].description | markdownify}}</p>
   <p>
   The official URL for this extension is:


### PR DESCRIPTION
This does the same thing but is simpler and more consistent with the other templates and QA.  also there is no {{modelType}} for extensions  (oops)

Example

![image](https://user-images.githubusercontent.com/7410922/96627832-47103080-12c6-11eb-887a-6c47d08c47c9.png)
