### PR TITLE
update css for external link to fix https issue

### DIFF
--- a/content/assets/css/project.css
+++ b/content/assets/css/project.css
@@ -129,7 +129,7 @@ body {
 #segment-footer > .container .inner-wrapper > p {
   padding-bottom: 0px;
   margin-bottom: 0px;
-  color:var(--footer-text-color); 
+  color:var(--footer-text-color);
 }
 #segment-post-footer {
   background-color: #f5f5f5;
@@ -242,7 +242,7 @@ body {
   background-image: url('../images/dragon.png');
   background-size: 150px 150px;
   display: inline-block;
-  float:left; 
+  float:left;
   margin-right: 10px;
   width: 150px;
   height: 150px;
@@ -633,14 +633,14 @@ a[href$=".sch"]:after, a[href$=".xlsx"]:after, a[href$=".zip"]:after, a[href$=".
 }
 
 /* =========== external links ============= */
-p a[href^="http://"]:not([no-external^="true"]):after, a[href^="https://"]:not([no-external^="true"]):after {
+p a[href^="http://"]:not([no-external^="true"]):after,p a[href^="https://"]:not([no-external^="true"]):after {
     content: url(../images/external.png);
     display: inline-block;
     text-decoration: none;
     padding-left: 3px;
 }
 
-li a[href^="http://"]:not([no-external^="true"]):after, a[href^="https://"]:not([no-external^="true"]):after {
+li a[href^="http://"]:not([no-external^="true"]):after,li a[href^="https://"]:not([no-external^="true"]):after {
     content: url(../images/external.png);
     display: inline-block;
     text-decoration: none;
@@ -698,7 +698,7 @@ li a[href^="http://"]:not([no-external^="true"]):after, a[href^="https://"]:not(
   padding-left: 7px;
   padding-right: 7px;
   float: right ; /* none or right */
-  border-radius: 6px; 
+  border-radius: 6px;
   border: 0.5px solid #ffffff;
 }
 


### PR DESCRIPTION
for issue and background and solution See Zulip chat here: https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Redirect.20to.20secure.20hl7.20page

see lines 637 an 643

example of fix rendering:  

![image](https://user-images.githubusercontent.com/7410922/124199018-d7725800-da86-11eb-804b-c62fac22e102.png)
the table data elements no longer have external links for https anchors