### PR TITLE
escape title in templates because it can contain non-html escaped characters (like &)

### DIFF
--- a/includes/fragment-pagebegin.html
+++ b/includes/fragment-pagebegin.html
@@ -3,7 +3,7 @@
 <html xml:lang="en" xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
-    <title>{{site.data.fhir.igId | upcase}}\{{site.data.pages[page.path].title}} - FHIR v{{site.data.fhir.version}}</title>
+    <title>{{site.data.fhir.igId | upcase}}\{{site.data.pages[page.path].title | escape_once}} - FHIR v{{site.data.fhir.version}}</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="author" content="http://hl7.org/fhir"/>
@@ -50,7 +50,7 @@
 {% assign status = site.data.fhir.ig.status %}
 {% endif %}
         <div id="ig-status">
-          <p><span style="font-size:12pt;font-weight:bold">{{site.data.fhir.ig.title}}</span><br/>{{site.data.fhir.ig.version}} - {{status}}</p>
+          <p><span style="font-size:12pt;font-weight:bold">{{site.data.fhir.ig.title | escape_once}}</span><br/>{{site.data.fhir.ig.version}} - {{status}}</p>
         </div>
       </div> <!-- /container -->
     </div>  <!-- /segment-header -->

--- a/includes/template-page-md.html
+++ b/includes/template-page-md.html
@@ -8,7 +8,7 @@ h6:before{color:silver;counter-increment:more-detail;content:var(--heading-prefi
 </style>
 <div class="col-12">
   <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
-  <h2>{{site.data.pages[page.path].title}}</h2>
+  <h2>{{site.data.pages[page.path].title | escape_once}}</h2>
   {% assign path = page.path | split: '.html' %}
 
 {% capture toc-content %} <!-- white space is critical inside of capture -->

--- a/includes/template-page.html
+++ b/includes/template-page.html
@@ -8,7 +8,7 @@ h6:before{color:silver;counter-increment:more-detail;content:var(--heading-prefi
 </style>
 <div class="col-12">
   <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
-  <h2>{{site.data.pages[page.path].title}}</h2>
+  <h2>{{site.data.pages[page.path].title | escape_once}}</h2>
   {% assign path = page.path | split: '.html' %}
   {% include {{path}}.xml %}
 </div>

--- a/layouts/layout-codesystem.html
+++ b/layouts/layout-codesystem.html
@@ -5,7 +5,7 @@
   <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
   {% include fragment-base-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
   <a name="root"> </a>
-  <h2 id="root">CodeSystem: {{site.data.pages[page.path].title}}</h2>
+  <h2 id="root">CodeSystem: {{site.data.pages[page.path].title | escape_once}}</h2>
 
   <!-- insert intro if present -->
   {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}

--- a/layouts/layout-conceptmap.html
+++ b/layouts/layout-conceptmap.html
@@ -6,7 +6,7 @@
   {% include fragment-base-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
   <a name="root"> </a>
 
-  <h2 id="root">ConceptMap: {{site.data.pages[page.path].title}}</h2>
+  <h2 id="root">ConceptMap: {{site.data.pages[page.path].title | escape_once}}</h2>
 
   <!-- insert intro if present -->
   {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}

--- a/layouts/layout-ext.html
+++ b/layouts/layout-ext.html
@@ -5,7 +5,7 @@
   <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
   {% include fragment-profile-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
   <a name="root"> </a>
-  <h2 id="root">Extension: {{site.data.pages[page.path].title}}</h2>
+  <h2 id="root">Extension: {{site.data.pages[page.path].title | escape_once}}</h2>
   <p>{{site.data.structuredefinitions['{{[id]}}'].description | markdownify}}</p>
   <p>
   The official URL for this extension is:

--- a/layouts/layout-instance-base.html
+++ b/layouts/layout-instance-base.html
@@ -11,7 +11,7 @@
   {% assign example = 'Example ' %}
 {% endif %}
 {% assign prefix = site.data.artifacts[page.path].type %}
-  <h2 id="root">{{example}}{{prefix}}: {{site.data.pages[page.path].title}}</h2>
+  <h2 id="root">{{example}}{{prefix}}: {{site.data.pages[page.path].title | escape_once}}</h2>
 
 {% unless example %}
   {% if '{{[type]}}' == 'CapabilityStatement' %}

--- a/layouts/layout-instance-format.html
+++ b/layouts/layout-instance-format.html
@@ -19,7 +19,7 @@
   {% assign example = 'Example ' %}
 {% endif %}
 {% assign prefix = site.data.artifacts[page.path].type %}
-<h2 id="root">{{example}}{{prefix}}: {{site.data.pages[page.path].title}}</h2>
+<h2 id="root">{{example}}{{prefix}}: {{site.data.pages[page.path] | escape_once}}</h2>
 
 <p><a href="{{[type]}}-{{[id]}}.{{[fmt]}}" no-download="true">Raw {{[fmt]}}</a> | <a href="{{[type]}}-{{[id]}}.{{[fmt]}}" download>Download</a></p>
 

--- a/layouts/layout-instance-format.html
+++ b/layouts/layout-instance-format.html
@@ -19,7 +19,7 @@
   {% assign example = 'Example ' %}
 {% endif %}
 {% assign prefix = site.data.artifacts[page.path].type %}
-<h2 id="root">{{example}}{{prefix}}: {{site.data.pages[page.path] | escape_once}}</h2>
+<h2 id="root">{{example}}{{prefix}}: {{site.data.pages[page.path].title | escape_once}}</h2>
 
 <p><a href="{{[type]}}-{{[id]}}.{{[fmt]}}" no-download="true">Raw {{[fmt]}}</a> | <a href="{{[type]}}-{{[id]}}.{{[fmt]}}" download>Download</a></p>
 

--- a/layouts/layout-profile-examples.html
+++ b/layouts/layout-profile-examples.html
@@ -22,7 +22,7 @@
       {% for example in site.data.pages[basepath].examples %}
         <tr>
           <td>
-            <a href="{{example.url}}">{{example.title}}</a>
+            <a href="{{example.url}}">{{example.title | escape_once}}</a>
           </td>
         </tr>
       {% endfor %}

--- a/layouts/layout-profile.html
+++ b/layouts/layout-profile.html
@@ -9,7 +9,7 @@
   {% include fragment-profile-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
 
   <a name="root"> </a>
-  <h2 id="root">{{modelType}}: {{site.data.pages[page.path].title}}</h2>
+  <h2 id="root">{{modelType}}: {{site.data.pages[page.path].title | escape_once}}</h2>
 
 {% include {{[type]}}-{{[id]}}-summary-table.xhtml type='{{[type]}}' id='{{[id]}}' %}
 

--- a/layouts/layout-valueset.html
+++ b/layouts/layout-valueset.html
@@ -5,7 +5,7 @@
   <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
   {% include fragment-base-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
   <a name="root"> </a>
-  <h2 id="root">ValueSet: {{site.data.pages[page.path].title}}</h2>
+  <h2 id="root">ValueSet: {{site.data.pages[page.path].title | escape_once}}</h2>
   <p>
     <b>Summary</b>
   </p>


### PR DESCRIPTION
the template does currently not escape the title of the pages.

the title feeded into jekyll comes from temp/pages/_data pages.json, and the entries in there can contain characters which need to be escaped (& is a character which is not escaped in json).

this PR changes the template that the title are escaped.