### PR TITLE
for notes in XML, remove div that enforces display:inline-block in fragment-notes.html

### DIFF
--- a/includes/fragment-notes.html
+++ b/includes/fragment-notes.html
@@ -2,9 +2,7 @@
 {% if notes != null %}
 <h3>Notes:</h3>
 {% if site.data.pages[page.path].notes-type == 'xml' %}
-<div style="display:inline-block">
 {% include {{notes}} type=include.type id=include.id %}
-</div>
 {% else %}
 {% capture note-content %}
 {% include {{notes}} type=include.type id=include.id %}


### PR DESCRIPTION
The display:inline-block forces content to be very narrow, so at least that style needs to be removed to allow the content creators to use the full width of the inner wrapper. 

Also, when including the notes from an xml (XHTML) file, the publisher verifies that the fragment is valid and in the xhtml namespace, therefore there is a valid single element that encompasses the included notes - the div itself is unnecessary.

@lmckenzi 
