### PR TITLE
Remove Testing nav tab from non-Canonical resource type pages

### DIFF
--- a/config.json
+++ b/config.json
@@ -137,7 +137,7 @@
     },
     "CodeSystem": {
       "template-base": "template/layouts/layout-codesystem.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -147,7 +147,7 @@
     },
     "ValueSet": {
       "template-base": "template/layouts/layout-valueset.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -157,7 +157,7 @@
     },
     "ActivityDefinition": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -167,7 +167,7 @@
     },
     "ActorDefinition": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -177,7 +177,7 @@
     },
     "CapabilityStatement": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -187,7 +187,7 @@
     },
     "ConceptMap": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -197,7 +197,7 @@
     },
     "EventDefinition": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -207,7 +207,7 @@
     },
     "GraphDefinition": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -217,7 +217,7 @@
     },
     "Library": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -227,7 +227,7 @@
     },
     "Measure": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -237,7 +237,7 @@
     },
     "MeasureDefinition": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -247,7 +247,7 @@
     },
     "MessageDefinition": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -257,7 +257,7 @@
     },
     "NamingSystem": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -267,7 +267,7 @@
     },
     "OperationDefinition": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -277,7 +277,7 @@
     },
     "PlanDefinition": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -287,7 +287,7 @@
     },
     "Questionnaire": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -297,7 +297,7 @@
     },
     "Requirements": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -307,7 +307,7 @@
     },
     "SearchParameter": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -317,7 +317,7 @@
     },
     "StructureMap": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -327,7 +327,7 @@
     },
     "TerminologyCapabilities": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",
@@ -337,7 +337,7 @@
     },
     "TestScript": {
       "template-base": "template/layouts/layout-canonical.html",
-      "template-format": "template/layouts/layout-instance-format.html",
+      "template-format": "template/layouts/layout-canonical-format.html",
       "template-testing": "template/layouts/layout-canonical-testing.html",
       "template-change-history": "template/layouts/layout-changehistory.html",
       "base": "{{[type]}}-{{[id]}}.html",

--- a/includes/fragment-canonical-navtabs.html
+++ b/includes/fragment-canonical-navtabs.html
@@ -26,6 +26,17 @@
     <a href="{{include.type}}-{{include.id}}.html">Narrative Content</a>
   </li>
 {% endif %}
+{% unless site.data.pages[basepath].testscripts.size == 0 %}
+  {% if include.active == 'testing' %}
+    <li class="active">
+      <a href="#">Testing</a>
+    </li>
+  {% else %}
+    <li>
+      <a href="{{include.type}}-{{include.id}}-testing.html">Testing</a>
+    </li>
+  {% endif %}
+{% endunless %}
 {% unless excludexml == 'y' or contained_resource == 'y' or suppressformat == 'y' %}
   {% if include.active == 'xml' %}
     <li class="active">

--- a/layouts/layout-canonical-format.html
+++ b/layouts/layout-canonical-format.html
@@ -1,0 +1,36 @@
+---
+---
+
+{% if '{{[fmt]}}' == 'xml' %}
+{% assign section = '7' %}
+{% elsif '{{[fmt]}}' == 'json' %}
+{% assign section = '8' %}
+{% else %}
+{% assign section = '9' %}
+{% endif %}
+
+{% include fragment-pagebegin.html %}
+<div style="counter-reset: section {{section}}" class="col-12">
+<!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
+{% include fragment-canonical-navtabs.html type='{{[type]}}' id='{{[id]}}' active='{{[fmt]}}' %}
+
+<a name="root"> </a>
+{% if site.data.artifacts[page.path].example %}
+  {% assign example = 'Example ' %}
+{% endif %}
+{% assign prefix = site.data.artifacts[page.path].type %}
+<h2 id="root">{{example}}{{prefix}}: {{site.data.pages[page.path].title | escape_once}}</h2>
+{% include fragment-simpletable.html %}
+
+<p><a href="{{[type]}}-{{[id]}}.{{[fmt]}}" no-download="true">Raw {{[fmt]}}</a> | <a href="{{[type]}}-{{[id]}}.{{[fmt]}}" download>Download</a></p>
+
+  <!-- insert intro if present -->
+  {% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
+
+  {% include {{[type]}}-{{[name]}}.xhtml %}
+
+  <!-- insert notes if present -->
+  {% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
+
+</div>
+{% include fragment-pageend.html %}

--- a/layouts/layout-canonical-testing.html
+++ b/layouts/layout-canonical-testing.html
@@ -3,7 +3,7 @@
 {% include fragment-pagebegin.html %}
 <div class="col-12">
   <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
-  {% include fragment-base-navtabs.html type='{{[type]}}' id='{{[id]}}' active='testing' %}
+  {% include fragment-canonical-navtabs.html type='{{[type]}}' id='{{[id]}}' active='testing' %}
   <a name="root"> </a>
   <h2 id="root">{{[type]}}: {{site.data.pages[page.path].title | escape_once}}
 {% if site.data.resources[resource_].experimental == true %}(Experimental){% endif %}

--- a/layouts/layout-canonical.html
+++ b/layouts/layout-canonical.html
@@ -3,7 +3,7 @@
 {% include fragment-pagebegin.html %}
 <div class="col-12">
   <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
-  {% include fragment-base-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
+  {% include fragment-canonical-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
   <a name="root"> </a>
 
   <h2 id="root">{{[type]}}: {{site.data.pages[page.path].title | escape_once}}

--- a/layouts/layout-codesystem.html
+++ b/layouts/layout-codesystem.html
@@ -3,7 +3,7 @@
 {% include fragment-pagebegin.html %}
 <div class="col-12">
   <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
-  {% include fragment-base-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
+  {% include fragment-canonical-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
   <a name="root"> </a>
   <h2 id="root">CodeSystem: {{site.data.pages[page.path].title | escape_once}}
 {% if site.data.resources[resource_].experimental == true %}(Experimental){% endif %}

--- a/layouts/layout-valueset.html
+++ b/layouts/layout-valueset.html
@@ -3,7 +3,7 @@
 {% include fragment-pagebegin.html %}
 <div class="col-12">
   <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
-  {% include fragment-base-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
+  {% include fragment-canonical-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
   <a name="root"> </a>
   <h2 id="root">ValueSet: {{site.data.pages[page.path].title | escape_once}}
 {% if site.data.resources[resource_].experimental == true %}(Experimental){% endif %}


### PR DESCRIPTION
### What does this Pull Request do?
Add and update components that limits the new "Testing" navigation tab and linked pages to only FHIR Canonical resource type pages.

### Why?
The FHIR community has been increasingly interested in provided better support for testing artifacts within IGs. These additional modified components are a subsequent update that allows IGs generated from the HL7 IG template to incorporate and list Testing resources as first class artifacts and with their associated/scoped FHIR Canonical resource types.

**Additional Information**
These updates are the results of the FHIR Zulip Chat reported issue with the THO UTG IG. See https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/THO.20.22testing.22.20tab.20in.20history.20bundles

### How?
New and updated components:
* **./config.json** - _Updated_
  * "**defaults**" list - update all canonical FHIR resource types attribute "template-format" value to the new "template/layouts/layout-canonical-format.html" layout page
* **./includes/fragment-base-navtabs.html** - _Updated_
  * Remove the **Testing** navigation tab logic - this fragment is used for non-canonical resource types
* **./includes/fragment-canonical-navtabs.html** - _New_
  * New navigation tab fragment for all "canonical" resource types - displays the new "Testing" nav tab only if linked testscript list size > 0
* **./layouts/layout-canonical-format.html** - _New_
  * New layout for all "canonical" resource types - copied from **./layouts/layout-instance-format.html**; _see **./config.json** above_
* **./layouts/layout-canonical-testing.html** - _Updated_
  * Replaced **./includes/fragment-base-navtabs.html** with **./includes/fragment-canonical-navtabs.html**
* **./layouts/layout-canonical.html** - _Updated_
  * Replaced **./includes/fragment-base-navtabs.html** with **./includes/fragment-canonical-navtabs.html**
* **./layouts/layout-codesystem.html** - _Updated_
  * Replaced **./includes/fragment-base-navtabs.html** with **./includes/fragment-canonical-navtabs.html**
* **./layouts/layout-valueset.html** - _Updated_
  * Replaced **./includes/fragment-base-navtabs.html** with **./includes/fragment-canonical-navtabs.html**

### Dependencies
These modifications are dependent on the IG Publisher tool modifications in the Pull Request https://github.com/HL7/fhir-ig-publisher/pull/518 now incorporated into the current (version 1.2.9+) IG Publisher tool.