### PR TITLE
Update navigation tab include fragments to correctly render "Testing" tab

### DIFF
--- a/includes/fragment-base-navtabs.html
+++ b/includes/fragment-base-navtabs.html
@@ -4,7 +4,6 @@
 {% assign excludelogbinaryformat = site.data.info.excludelogbinaryformat | downcase | slice: 0 %}
 {% assign resource_ = include.type| append: '/'| append: include.id  %}
 {% assign has_history = site.data.resources[resource_].['history'] %}
-{% assign basepath = include.type | append: '-' | append: include.id | append: '.html' %}
 {% if site.data.resources[resource_].sourceTail contains "#" %}
 {% assign contained_resource = 'y' %}
 {% endif %}
@@ -26,7 +25,7 @@
     <a href="{{include.type}}-{{include.id}}.html">Narrative Content</a>
   </li>
 {% endif %}
-{% unless site.data.pages[basepath].testscripts.size == 0 %}
+{% if site.data.resources[resource_].['testscript'] %}
   {% if include.active == 'testing' %}
     <li class="active">
       <a href="#">Testing</a>
@@ -36,7 +35,7 @@
       <a href="{{include.type}}-{{include.id}}-testing.html">Testing</a>
     </li>
   {% endif %}
-{% endunless %}
+{% endif %}
 {% unless excludexml == 'y' or contained_resource == 'y' or suppressformat == 'y' %}
   {% if include.active == 'xml' %}
     <li class="active">

--- a/includes/fragment-profile-navtabs.html
+++ b/includes/fragment-profile-navtabs.html
@@ -45,7 +45,7 @@
   {% endif %}
 {% endunless %}
 
-{% unless site.data.pages[basepath].testscripts.size == 0 %}
+{% if site.data.resources[resource_].['testscript'] %}
   {% if include.active == 'testing' %}
     <li class="active">
       <a href="#">Testing</a>
@@ -55,7 +55,7 @@
       <a href="{{include.type}}-{{include.id}}-testing.html">Testing</a>
     </li>
   {% endif %}
-{% endunless %}
+{% endif %}
 
 {% unless example_count == 0 %}
 {% unless sd_type == 'Extension' %}


### PR DESCRIPTION
### What does this Pull Request do?
Update navigation tab include fragments that limit the new "Testing" navigation tab and linked pages to only resource pages that have found testing artifact(s).

### Why?
The FHIR community has been increasingly interested in provided better support for testing artifacts within IGs. These update correct IGs generated from the HL7 IG template to incorporate and list Testing resources as first class artifacts and with their associated/scoped FHIR Canonical resource types.

**Additional Information**
These updates are the results of the FHIR Zulip Chat reported issue with the THO UTG IG and the Da Vinci CDex IG. See https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/THO.20.22testing.22.20tab.20in.20history.20bundles
https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/.22testing.22.20tab.20with.20bad.20link.3F

### How?
Updated components:
* **./includes/fragment-base-navtabs.html** - _Updated_
  * Update the **Testing** navigation tab conditional rendering logic to use the current resource assigned "testscripts" boolean
* **./includes/fragment-profile-navtabs.html** - _Updated_
  * Update the **Testing** navigation tab conditional rendering logic to use the current resource assigned "testscripts" boolean

### Dependencies
These modifications are dependent on the IG Publisher tool modifications in the Pull Request https://github.com/HL7/fhir-ig-publisher/pull/518 now incorporated into the current (version 1.2.9+) IG Publisher tool.