### PR TITLE
escape titles and versions in page title

### DIFF
--- a/includes/fragment-pagebegin.html
+++ b/includes/fragment-pagebegin.html
@@ -3,7 +3,7 @@
 <html xml:lang="en" xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
-    <title>{{site.data.pages[page.path].title | escape_once}} - {{site.data.fhir.ig.title}} v{{site.data.fhir.ig.version}}</title>
+    <title>{{site.data.pages[page.path].title | escape_once}} - {{site.data.fhir.ig.title | escape_once}} v{{site.data.fhir.ig.version | escape_once}}</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="author" content="http://hl7.org/fhir"/>


### PR DESCRIPTION
IGs with "&" in the title would crash