### PR TITLE
Disabled auto-processing of guillemets

### DIFF
--- a/config/_config.yml
+++ b/config/_config.yml
@@ -1,3 +1,6 @@
 kramdown:
   toc_levels:    1..3
   smart_quotes: ["apos", "apos", "quot", "quot"]
+  typographic_symbols: 
+    "laquo": "<<"
+    "raquo": ">>"


### PR DESCRIPTION
Adding to the configuration here to disable the auto-processing of guillemet. By default, the current version of Jekyll will replace `<<` with `«` and `>>` with `»`